### PR TITLE
Updated per hw09 feedback:

### DIFF
--- a/hw09_djackson.py
+++ b/hw09_djackson.py
@@ -7,7 +7,6 @@ from prettytable import PrettyTable
 26Mar18
 SSW-810-A
 Assignment HW09
-Version: 1
 
 Module contains classes to construct and operate on a repository (Repo) of 
 education institution data including Students, Professors, and Courses. 
@@ -35,8 +34,6 @@ class Student:
 
     :assumption: Repo class will provide methods for Course object retrieval,
     so only need to store course name here, not full Course object.
-
-    :note: no functions needed at this time (V1)
     """
     def __init__(self, cwid, name, courses, major):
         self.cwid = cwid
@@ -55,8 +52,6 @@ class Professor:
 
     :assumption: Repo class will provide methods for Course object retrieval,
     so only need to store course name here, not full Course object.
-
-    :note: no functions needed at this time (V1)
     """
     def __init__(self, cwid, name, courses, dept):
         self.cwid = cwid
@@ -76,8 +71,6 @@ class Course:
 
     :assumption: Repo class provides methods for student and professor
     retrieval, so only need to store CWID for these, not full objects.
-
-    :note: no functions needed at this time (V1)
     """
     def __init__(self, name, students, prof, dept):
         self.name = name
@@ -94,32 +87,25 @@ class Repo:
     g_data to be correctly populated by read_file(). Much of this class is
     based on that assumption. If changed, pop_students(), pop_professors(),
     pop_courses(), and make_courses_table() will need updates.
-
-    :assumption: students, professors, and courses can be list objects at this
-    time since there is no current need for hashing by ID or name, but this can
-    be changed easily if future versions require it.
     """
     students = None  # list after init
     professors = None  # list after init
     courses = None  # dict after init
 
     def __init__(self, directory):
-        try:
-            std_data = read_file(directory + os.sep + "students.txt")
-            prof_data = read_file(directory + os.sep + "instructors.txt")
-            grade_data = read_file(directory + os.sep + "grades.txt")
+        std_data = read_file(os.path.join(directory, "students.txt"))
+        prof_data = read_file(os.path.join(directory, "instructors.txt"))
+        grade_data = read_file(os.path.join(directory, "grades.txt"))
 
-            self.students = self.pop_students(std_data, grade_data)
-            self.professors = self.pop_professors(prof_data, grade_data)
-            self.courses = self.pop_courses(grade_data)
-        except OSError as o:
-            print(o)
+        self.students = self.pop_students(std_data, grade_data)
+        self.professors = self.pop_professors(prof_data, grade_data)
+        self.courses = self.pop_courses(grade_data)
 
     def pop_students(self, s_data, g_data):
         """Transforms the s_data raw student data(with items from g_data)
         and returns a list of Student objects.
         """
-        list_of_students = []
+        list_of_students = {}
         for student, values in s_data.items():
             classes = {}
             for course_data in g_data:
@@ -127,15 +113,15 @@ class Repo:
                         course_data[2] != '' and \
                         course_data[2] != 'F':
                     classes[course_data[1]] = course_data[2]
-            list_of_students.append(Student(student, values[0],
-                                            classes, values[1]))
+            list_of_students[student] = Student(student, values[0],
+                                                classes, values[1])
         return list_of_students
 
     def pop_professors(self, p_data, g_data):
         """Transforms the p_data raw professor data(with items from g_data)
         and returns a list of Student objects.
         """
-        list_of_profs = []
+        list_of_profs = {}
         for prof, values in p_data.items():
             course_dict = {}
             for _, course, _, prf in g_data:
@@ -144,8 +130,8 @@ class Repo:
                         course_dict[course] = 1
                     else:
                         course_dict[course] += 1
-            list_of_profs.append(Professor(prof, values[0],
-                                           course_dict, values[1]))
+            list_of_profs[prof] = Professor(prof, values[0],
+                                            course_dict, values[1])
         return list_of_profs
 
     def pop_courses(self, g_data):
@@ -155,26 +141,10 @@ class Repo:
         for student, course, _, prof in g_data:
             if course not in list_of_courses.keys():
                 list_of_courses[course] = Course(course, [student], prof,
-                                                 self.get_professor(prof).dept)
+                                                 self.professors[prof].dept)
             else:
                 list_of_courses[course].students.append(student)
         return list_of_courses
-
-    def get_professor(self, cwid):
-        """Searches the professors list and returns the Professor object
-        matching the CWID or None if not found"""
-        for prof in self.professors:
-            if prof.cwid == cwid:
-                return prof
-        return None
-
-    def get_student(self, cwid):
-        """Searches the students list and returns the Student object
-        matching the CWID or None if not found"""
-        for student in self.students:
-            if student.cwid == cwid:
-                return student
-        return None
 
     def print_summary_tables(self):
         """Helper to reduce complexity of PrettyTable printers"""
@@ -190,9 +160,9 @@ class Repo:
         pt = PrettyTable(field_names=["CWID", "Name", "Major",
                                       "Completed Courses"])
         pt.align = 'l'
-        for student in self.students:
+        for _, student in self.students.items():
             pt.add_row([student.cwid, student.name,
-                        student.major, student.courses])
+                        student.major, sorted(student.courses.keys(),)])
         return pt
 
     def make_professor_table(self):
@@ -200,9 +170,9 @@ class Repo:
         pt = PrettyTable(field_names=["CWID", "Name", "Dept",
                                       "Taught Courses"])
         pt.align = 'l'
-        for professor in self.professors:
+        for _, professor in self.professors.items():
             pt.add_row([professor.cwid, professor.name,
-                        professor.dept, professor.courses])
+                        professor.dept, sorted(professor.courses.keys())])
         return pt
 
     def make_courses_table(self):
@@ -215,8 +185,8 @@ class Repo:
         pt.align = 'l'
         for key, course_data in self.courses.items():
             pt.add_row([course_data.prof,
-                        self.get_professor(course_data.prof).name,
-                        self.get_professor(course_data.prof).dept,
+                        self.professors[course_data.prof].name,
+                        self.professors[course_data.prof].dept,
                         course_data.name,
                         len(course_data.students)])
         return pt
@@ -229,7 +199,8 @@ def read_file(file):
     try:
         fp = open(file, 'r')
     except (FileNotFoundError, IOError):
-        raise OSError("--Error: file doesn't exist / can't open file")
+        raise OSError("--Error: {} doesn't exist or can't be "
+                      "opened for reading.".format(file))
     else:
         with fp:
             if file.endswith("grades.txt"):
@@ -239,10 +210,6 @@ def read_file(file):
                     if len(line_temp) == 4:
                         file_data.append((line_temp[0], line_temp[1],
                                           line_temp[2], line_temp[3]))
-                    else:
-                        pass
-                        # print("Incomplete class record, cannot parse")
-                        # @todo add elegant error handler
             else:
                 file_data = defaultdict(dict)
                 for line in fp:
@@ -255,7 +222,7 @@ def read_file(file):
 
 
 def main():
-    repo = Repo(r"C:\Users\Dan\PycharmProjects\hw09\normal")
+    repo = Repo(r"C:\Users\Dan\PycharmProjects\ssw810_hw_repo\normal")
     repo.print_summary_tables()
 
 

--- a/hw09tests.py
+++ b/hw09tests.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 from collections import defaultdict
 import hw09_djackson as h
 
@@ -17,63 +18,60 @@ hw09_djackson.py.
 class EduRepoTests(unittest.TestCase):
     """Class is a container for the Repo class and required inputs to that
     class (Student, Professor, Course classes and file_reader() function.
-    Test blocks will identify the test data required. All additional
-    test data will be delivered with this module."""
+    Test blocks will identify the test data set required via the path varibale.
+    All additional test data will be delivered with this module."""
 
     def test_file_reader(self):
-        """All tests require abbreviated data files in the TC1 folder."""
-        s = h.read_file(r"C:\Users\Dan\PycharmProjects\hw09\test\students.txt")
+        path = r"C:\Users\Dan\PycharmProjects\ssw810_hw_repo\test"
+        s = h.read_file(os.path.join(path, "students.txt"))
         self.assertEqual(type(s), defaultdict)
         self.assertEqual(s["10103"], ('Baldwin, C', 'SFEN'))
         self.assertEqual(s["10101"], {})
 
-        p = h.read_file(
-            r"C:\Users\Dan\PycharmProjects\hw09\test\instructors.txt")
+        p = h.read_file(os.path.join(path, "instructors.txt"))
         self.assertEqual(type(p), defaultdict)
         self.assertEqual(p["98765"], ('Einstein, A', 'SFEN'))
         self.assertEqual(p["0"], ('0', '0'))
         self.assertEqual(p["1"], ('', ''))
 
-        g = h.read_file(r"C:\Users\Dan\PycharmProjects\hw09\test\grades.txt")
+        g = h.read_file(os.path.join(path, "grades.txt"))
         self.assertEqual(type(g), list)
         self.assertEqual(g[0], ('10103', 'SSW 567', 'A', '98765'))
         self.assertEqual(g[4], ('0', '0', '0', '0'))
         with self.assertRaises(IndexError):
             print(g[5])
         with self.assertRaises(OSError):
-            h.read_file(r"C:\Users\Dan\PycharmProjects\hw09\test\nothere.txt")
+            h.read_file(os.path.join(path, "nothere.txt"))
 
     def test_repo_maker(self):
-        """Requires abbreviated data files in the TC1 folder."""
-        repo = h.Repo(r"C:\Users\Dan\PycharmProjects\hw09\test")
-        self.assertEqual(type(repo.students), list)
-        self.assertEqual(type(repo.professors), list)
+        path = r"C:\Users\Dan\PycharmProjects\ssw810_hw_repo\test"
+        repo = h.Repo(path)
+        self.assertEqual(type(repo.students), dict)
+        self.assertEqual(type(repo.professors), dict)
         self.assertEqual(type(repo.courses), dict)
 
     def test_student_list(self):
-        """Tests all student related functionality in Repo."""
-        repo = h.Repo(r"C:\Users\Dan\PycharmProjects\hw09\test")
-        s = repo.get_student("10103")
+        path = r"C:\Users\Dan\PycharmProjects\ssw810_hw_repo\test"
+        repo = h.Repo(path)
+        s = repo.students["10103"]
         self.assertEqual((s.cwid, s.name, s.courses, s.major),
                          ("10103", "Baldwin, C",
-                          {'SSW 567': 'A', 'SSW 564': 'A-'}, "SFEN"))
-        self.assertEqual(repo.get_student("444444"), None)
+                          {'SSW 564': 'A-', 'SSW 567': 'A'}, "SFEN"))
 
     def test_professor_list(self):
-        """Tests all professor related functionality in Repo."""
-        repo = h.Repo(r"C:\Users\Dan\PycharmProjects\hw09\test")
-        p = repo.get_professor("98765")
+        path = r"C:\Users\Dan\PycharmProjects\ssw810_hw_repo\test"
+        repo = h.Repo(path)
+        p = repo.professors["98765"]
         self.assertEqual((p.cwid, p.name, p.courses, p.dept),
                          ("98765", "Einstein, A",
                           {'SSW 567': 2}, "SFEN"))
-        self.assertEqual(repo.get_professor("444444"), None)
-        inc_p = repo.get_professor("1")  # tests incomplete professor record
+        inc_p = repo.professors["1"]  # tests incomplete professor record
         self.assertEqual((inc_p.cwid, inc_p.name, inc_p.courses, inc_p.dept),
                          ("1", "", {}, ""))
 
     def test_course_dict(self):
-        """Tests all course related functionality in Repo."""
-        repo = h.Repo(r"C:\Users\Dan\PycharmProjects\hw09\test")
+        path = r"C:\Users\Dan\PycharmProjects\ssw810_hw_repo\test"
+        repo = h.Repo(path)
         self.assertEqual(len(repo.courses), 3)
         c = repo.courses["SSW 567"]
         self.assertEqual((c.name, c.prof, c.dept, c.students),


### PR DESCRIPTION
1. Changed string seperator for path to os.path.join()
2. Simplified error handling (just do nothing on incorrect # terms for courses) so that it doesn't need the large try/catch in Repo.init()
3. Updated the exception error message to include the filename
4. Tweaked the read_file() function but kept the same overall design (specify a path and let the function figure out which type of file it is)
5. Changed the Repo.students and Repo.professors containers to dictionaries. This eliminated a few unittest subcases since there's no longer a get_student() or get_professor() function.
6. Updated table makers to use the new dictionaries for students and professors and to sort courses on make. With this, the table no longer prints the grade for each course, just the course title.
7. Updated unit tests as applicable.